### PR TITLE
Entrypoint cleanup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,8 +4,6 @@ set -e
 NAME='elasticsearch'
 
 if [ "$1" = "$NAME" ]; then
-  MAX_OPEN_FILES=65535
-
   # Those are just defaults, they can be overriden with -Des.config=...
   CONF_DIR=/etc/$NAME
   CONF_FILE=$CONF_DIR/elasticsearch.yml
@@ -14,10 +12,6 @@ if [ "$1" = "$NAME" ]; then
 
   OPTS="--default.config=$CONF_FILE --default.path.home=$ES_HOME --default.path.logs=$ES_LOGS --default.path.data=$ES_DATA --default.path.work=$WORK_DIR --default.path.conf=$CONF_DIR"
   mkdir -p "$ES_LOGS" "$ES_DATA" "$WORK_DIR" && chown -R "$ES_USER":"$ES_GROUP" "$ES_LOGS" "$ES_DATA" "$WORK_DIR"
-
-  if [ -n "$MAX_OPEN_FILES" ]; then
-    ulimit -n $MAX_OPEN_FILES
-  fi
 
   shift
   exec gosu "$ES_USER:$ES_GROUP" "$NAME" $OPTS "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "$NAME" ]; then
   mkdir -p "$ES_LOGS" "$ES_DATA" "$WORK_DIR" && chown -R "$ES_USER":"$ES_GROUP" "$ES_LOGS" "$ES_DATA" "$WORK_DIR"
 
   shift
-  exec gosu "$ES_USER:$ES_GROUP" "$NAME" $OPTS "$@"
+  set -- gosu "$ES_USER:$ES_GROUP" "$NAME" $OPTS "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Removed `MAX_OPEN_FILES` logic since it doesn't actually work inside a container (at least not for raising the ulimit). Changed from having multiple `exec` exit points to using `set --` to update `$@`.
